### PR TITLE
Update alt text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Get the time zone used at the given coordinates
 
 [![Latest Version](https://img.shields.io/github/release/spatie/google-time-zone.svg?style=flat-square)](https://github.com/spatie/google-time-zone/releases)
-[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
+[![MIT Licensed](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
 [![Build Status](https://img.shields.io/travis/spatie/google-time-zone/master.svg?style=flat-square)](https://travis-ci.org/spatie/google-time-zone)
 [![Quality Score](https://img.shields.io/scrutinizer/g/spatie/google-time-zone.svg?style=flat-square)](https://scrutinizer-ci.com/g/spatie/google-time-zone)
 [![StyleCI](https://github.styleci.io/repos/183008491/shield?branch=master)](https://github.styleci.io/repos/183008491)


### PR DESCRIPTION
If the bade doesn't load, this will still allow users to see what the license is. It is also beneficial for users who use screen readers.