### PR TITLE
Add Laravel 9 Support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,10 +9,12 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ ubuntu-latest ]
-                php: [ 7.4, 7.3, 7.2, 8.0 ]
-                laravel: [ 6.*, 7.*, 8.* ]
+                php: [ 7.4, 7.3, 7.2, 8.0, 8.1 ]
+                laravel: [ 6.*, 7.*, 8.*, 9.* ]
                 dependency-version: [ prefer-lowest, prefer-stable ]
                 include:
+                    -   laravel: 9.*
+                        testbench: 7.*
                     -   laravel: 8.*
                         testbench: 6.*
                     -   laravel: 7.*
@@ -20,6 +22,8 @@ jobs:
                     -   laravel: 6.*
                         testbench: 4.*
                 exclude:
+                    -   laravel: 9.*
+                        php: 7.2
                     -   laravel: 8.*
                         php: 7.2
                     -   laravel: 8.*

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
     ],
     "require" : {
         "php" : "^7.2|^8.0",
-        "illuminate/support" : "^6.0|^7.0|^8.0",
+        "illuminate/support" : "^6.0|^7.0|^8.0|^9.0",
         "guzzlehttp/guzzle" : "^6.5|^7.0",
         "ext-json" : "*"
     },
     "require-dev" : {
         "phpunit/phpunit" : "^8.0|^9.0",
-        "orchestra/testbench" : "^4.0|^5.0|^6.0"
+        "orchestra/testbench" : "^4.0|^5.0|^6.0|^7.0"
     },
     "autoload" : {
         "psr-4" : {


### PR DESCRIPTION
# Added
- Laravel 9.x support in `composer.json`
- Add tests matrix for Laravel 9.x and PHP 8.1 in `run-tests.yml`