### PR TITLE
Fix implicit nullable deprecation

### DIFF
--- a/src/GoogleTimeZone.php
+++ b/src/GoogleTimeZone.php
@@ -24,7 +24,7 @@ class GoogleTimeZone
     /** @var \DateTimeInterface|null */
     protected $timestamp;
 
-    public function __construct(Client $client = null)
+    public function __construct(?Client $client = null)
     {
         $this->client = $client ?? new Client();
     }


### PR DESCRIPTION
This fixes the implicitly nullable parameter issue below that was deprecated in PHP 8.4.

`Spatie\GoogleTimeZone\GoogleTimeZone::__construct(): Implicitly marking parameter $client as nullable is deprecated, the explicit nullable type must be used instead`